### PR TITLE
Diamond Shaped Controlled Sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@ __pycache__/
 .ipynb_checkpoints/
 
 # Library artifacts
-lgui.egg-info/
+lcapy_gui.egg-info/
 dist/
+build/
 
 # Local testing files
 test.py

--- a/lcapygui/components/cccs.py
+++ b/lcapygui/components/cccs.py
@@ -48,11 +48,25 @@ class CCCS(Component):
             end[0], end[1]
         )
 
-        # circle
-        layer.stroke_arc(
-            mid[0], mid[1],
-            RADIUS,
-            0, 2 * np.pi
+        # diamond
+        h_shift = RADIUS * self.orthog()
+        v_shift = RADIUS * self.along()
+
+        layer.stroke_line(
+            mid[0] + v_shift[0], mid[1] + v_shift[1],
+            mid[0] + h_shift[0], mid[1] + h_shift[1]
+        )
+        layer.stroke_line(
+            mid[0] + h_shift[0], mid[1] + h_shift[1],
+            mid[0] - v_shift[0], mid[1] - v_shift[1]
+        )
+        layer.stroke_line(
+            mid[0] - v_shift[0], mid[1] - v_shift[1],
+            mid[0] - h_shift[0], mid[1] - h_shift[1]
+        )
+        layer.stroke_line(
+            mid[0] - h_shift[0], mid[1] - h_shift[1],
+            mid[0] + v_shift[0], mid[1] + v_shift[1]
         )
 
         # arrow

--- a/lcapygui/components/ccvs.py
+++ b/lcapygui/components/ccvs.py
@@ -48,11 +48,25 @@ class CCVS(Component):
             end[0], end[1]
         )
 
-        # circle
-        layer.stroke_arc(
-            mid[0], mid[1],
-            RADIUS,
-            0, 2 * np.pi
+        # diamond
+        h_shift = RADIUS * self.orthog()
+        v_shift = RADIUS * self.along()
+
+        layer.stroke_line(
+            mid[0] + v_shift[0], mid[1] + v_shift[1],
+            mid[0] + h_shift[0], mid[1] + h_shift[1]
+        )
+        layer.stroke_line(
+            mid[0] + h_shift[0], mid[1] + h_shift[1],
+            mid[0] - v_shift[0], mid[1] - v_shift[1]
+        )
+        layer.stroke_line(
+            mid[0] - v_shift[0], mid[1] - v_shift[1],
+            mid[0] - h_shift[0], mid[1] - h_shift[1]
+        )
+        layer.stroke_line(
+            mid[0] - h_shift[0], mid[1] - h_shift[1],
+            mid[0] + v_shift[0], mid[1] + v_shift[1]
         )
 
         # plus/minus signs

--- a/lcapygui/components/port.py
+++ b/lcapygui/components/port.py
@@ -1,0 +1,9 @@
+from .component import Component
+
+
+class Port(Component):
+    """
+        Placeholder port to fix import errors.
+        TOFIX
+    """
+    pass

--- a/lcapygui/components/vccs.py
+++ b/lcapygui/components/vccs.py
@@ -48,11 +48,25 @@ class VCCS(Component):
             end[0], end[1]
         )
 
-        # circle
-        layer.stroke_arc(
-            mid[0], mid[1],
-            RADIUS,
-            0, 2 * np.pi
+        # diamond
+        h_shift = RADIUS * self.orthog()
+        v_shift = RADIUS * self.along()
+
+        layer.stroke_line(
+            mid[0] + v_shift[0], mid[1] + v_shift[1],
+            mid[0] + h_shift[0], mid[1] + h_shift[1]
+        )
+        layer.stroke_line(
+            mid[0] + h_shift[0], mid[1] + h_shift[1],
+            mid[0] - v_shift[0], mid[1] - v_shift[1]
+        )
+        layer.stroke_line(
+            mid[0] - v_shift[0], mid[1] - v_shift[1],
+            mid[0] - h_shift[0], mid[1] - h_shift[1]
+        )
+        layer.stroke_line(
+            mid[0] - h_shift[0], mid[1] - h_shift[1],
+            mid[0] + v_shift[0], mid[1] + v_shift[1]
         )
 
         # arrow

--- a/lcapygui/components/vcvs.py
+++ b/lcapygui/components/vcvs.py
@@ -48,11 +48,25 @@ class VCVS(Component):
             end[0], end[1]
         )
 
-        # circle
-        layer.stroke_arc(
-            mid[0], mid[1],
-            RADIUS,
-            0, 2 * np.pi
+        # diamond
+        h_shift = RADIUS * self.orthog()
+        v_shift = RADIUS * self.along()
+
+        layer.stroke_line(
+            mid[0] + v_shift[0], mid[1] + v_shift[1],
+            mid[0] + h_shift[0], mid[1] + h_shift[1]
+        )
+        layer.stroke_line(
+            mid[0] + h_shift[0], mid[1] + h_shift[1],
+            mid[0] - v_shift[0], mid[1] - v_shift[1]
+        )
+        layer.stroke_line(
+            mid[0] - v_shift[0], mid[1] - v_shift[1],
+            mid[0] - h_shift[0], mid[1] - h_shift[1]
+        )
+        layer.stroke_line(
+            mid[0] - h_shift[0], mid[1] - h_shift[1],
+            mid[0] + v_shift[0], mid[1] + v_shift[1]
         )
 
         # plus/minus signs


### PR DESCRIPTION
I've updated the controlled sources to have diamond shaped containers rather than the previous circle ones.
I've also updated the gitignore and add a port placeholder as I had some trouble building without these --- I can remove these and re-open the pull request if you would prefer.